### PR TITLE
Fix build failures by adding missing module files

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,0 +1,256 @@
+//! Command-line argument parser
+//!
+//! Parses command-line arguments for Ferrous, with Redis compatibility.
+
+use std::path::PathBuf;
+
+/// Command-line arguments for Ferrous
+#[derive(Debug, Clone)]
+pub struct CliArgs {
+    /// Configuration file path
+    pub config: Option<PathBuf>,
+    
+    /// Port to listen on
+    pub port: Option<u16>,
+    
+    /// Address to bind to 
+    pub bind: Option<String>,
+    
+    /// Password for authentication
+    pub password: Option<String>,
+    
+    /// Master to replicate from - (host, port)
+    pub replicaof: Option<(String, u16)>,
+    
+    /// Directory for data files
+    pub dir: Option<String>,
+    
+    /// Database filename
+    pub dbfilename: Option<String>,
+    
+    /// Enable AOF
+    pub appendonly: bool,
+    
+    /// Logfile path
+    pub logfile: Option<String>,
+    
+    /// Log level (debug, verbose, notice, warning)
+    pub loglevel: Option<String>,
+    
+    /// Whether to fork and run in the background
+    pub daemonize: Option<bool>,
+}
+
+impl Default for CliArgs {
+    fn default() -> Self {
+        CliArgs {
+            config: None,
+            port: None,
+            bind: None,
+            password: None,
+            replicaof: None,
+            dir: None,
+            dbfilename: None,
+            appendonly: false,
+            logfile: None,
+            loglevel: None,
+            daemonize: None,
+        }
+    }
+}
+
+/// Parse command-line arguments
+pub fn parse_cli_args() -> CliArgs {
+    // Get args without program name
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        return CliArgs::default();
+    }
+    
+    let mut cli_args = CliArgs::default();
+    let mut i = 0;
+    
+    while i < args.len() {
+        match args[i].as_str() {
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            "--version" | "-v" => {
+                println!("Ferrous {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "--config" | "-c" => {
+                if i + 1 < args.len() {
+                    cli_args.config = Some(PathBuf::from(&args[i + 1]));
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --config");
+                    std::process::exit(1);
+                }
+            }
+            "--port" | "-p" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u16>() {
+                        Ok(port) => cli_args.port = Some(port),
+                        Err(_) => {
+                            eprintln!("Error: Invalid port number: {}", args[i + 1]);
+                            std::process::exit(1);
+                        }
+                    }
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --port");
+                    std::process::exit(1);
+                }
+            }
+            "--bind" => {
+                if i + 1 < args.len() {
+                    cli_args.bind = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --bind");
+                    std::process::exit(1);
+                }
+            }
+            "--password" | "--requirepass" => {
+                if i + 1 < args.len() {
+                    cli_args.password = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --password");
+                    std::process::exit(1);
+                }
+            }
+            "--replicaof" | "--slaveof" => {
+                if i + 2 < args.len() {
+                    match args[i + 2].parse::<u16>() {
+                        Ok(port) => cli_args.replicaof = Some((args[i + 1].clone(), port)),
+                        Err(_) => {
+                            eprintln!("Error: Invalid port number for --replicaof: {}", args[i + 2]);
+                            std::process::exit(1);
+                        }
+                    }
+                    i += 3;
+                } else {
+                    eprintln!("Error: Missing arguments for --replicaof");
+                    std::process::exit(1);
+                }
+            }
+            "--dir" => {
+                if i + 1 < args.len() {
+                    cli_args.dir = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --dir");
+                    std::process::exit(1);
+                }
+            }
+            "--dbfilename" => {
+                if i + 1 < args.len() {
+                    cli_args.dbfilename = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --dbfilename");
+                    std::process::exit(1);
+                }
+            }
+            "--appendonly" => {
+                if i + 1 < args.len() && (args[i + 1] == "yes" || args[i + 1] == "no") {
+                    cli_args.appendonly = args[i + 1] == "yes";
+                    i += 2;
+                } else {
+                    // Just --appendonly with no argument means enable it
+                    cli_args.appendonly = true;
+                    i += 1;
+                }
+            }
+            "--logfile" => {
+                if i + 1 < args.len() {
+                    cli_args.logfile = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --logfile");
+                    std::process::exit(1);
+                }
+            }
+            "--loglevel" => {
+                if i + 1 < args.len() {
+                    cli_args.loglevel = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: Missing argument for --loglevel");
+                    std::process::exit(1);
+                }
+            }
+            "--daemonize" => {
+                if i + 1 < args.len() && (args[i + 1] == "yes" || args[i + 1] == "no") {
+                    cli_args.daemonize = Some(args[i + 1] == "yes");
+                    i += 2;
+                } else {
+                    // Just --daemonize with no argument means enable it
+                    cli_args.daemonize = Some(true);
+                    i += 1;
+                }
+            }
+            arg => {
+                // Check if it's a config file path without --config flag
+                if arg.ends_with(".conf") {
+                    cli_args.config = Some(PathBuf::from(arg));
+                    i += 1;
+                } else {
+                    eprintln!("Error: Unknown argument: {}", arg);
+                    print_help();
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+    
+    cli_args
+}
+
+/// Print help information
+fn print_help() {
+    println!("Usage: ferrous [OPTIONS] [/path/to/ferrous.conf]");
+    println!("       ferrous --port 6379");
+    println!("       ferrous /etc/ferrous.conf --loglevel debug");
+    println!();
+    println!("Options:");
+    println!("  --help, -h              Show this help message");
+    println!("  --version, -v           Show version information");
+    println!("  --config, -c  <file>    Configuration file to use");
+    println!("  --port, -p    <port>    TCP port to listen on (default: 6379)");
+    println!("  --bind        <address> Interface to bind to (default: 127.0.0.1)");
+    println!("  --password    <password> Server password");
+    println!("  --replicaof   <host> <port> Make this server a replica of another instance");
+    println!("  --dir         <dir>     Working directory for database files");
+    println!("  --dbfilename  <filename> Database filename");
+    println!("  --appendonly  [yes|no]  Enable append-only file persistence");
+    println!("  --logfile     <file>    Path to log file (empty for stdout)");
+    println!("  --loglevel    <level>   Log level (debug, verbose, notice, warning)");
+    println!("  --daemonize   [yes|no]  Run as a daemon in the background");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_cli_args() {
+        // Test with args
+        let mut args = CliArgs::default();
+        args.port = Some(9999);
+        args.password = Some("secret".to_string());
+        
+        assert_eq!(args.port, Some(9999));
+        assert_eq!(args.password, Some("secret".to_string()));
+        assert_eq!(args.replicaof, None);
+        
+        // Test with replicaof
+        let mut args = CliArgs::default();
+        args.replicaof = Some(("master.example.com".to_string(), 6379));
+        
+        assert_eq!(args.replicaof, Some(("master.example.com".to_string(), 6379)));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,278 @@
+//! Configuration module for Ferrous
+//! 
+//! Provides a centralized configuration system that supports both
+//! configuration files and command-line arguments.
+
+mod parser;
+mod cli;
+
+pub use parser::{parse_config_file, ConfigParseError};
+pub use cli::{parse_cli_args, CliArgs};
+
+use crate::network::NetworkConfig;
+use crate::storage::{RdbConfig, AofConfig};
+use crate::storage::memory::EvictionPolicy;
+use crate::replication::ReplicationConfig;
+
+use std::path::PathBuf;
+
+/// Main configuration structure for Ferrous
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Server configuration
+    pub server: ServerConfig,
+    
+    /// Network configuration
+    pub network: NetworkConfig,
+    
+    /// RDB persistence configuration
+    pub rdb: RdbConfig,
+    
+    /// AOF persistence configuration
+    pub aof: AofConfig,
+    
+    /// Replication configuration
+    pub replication: ReplicationConfig,
+    
+    /// Memory management configuration
+    pub memory: MemoryConfig,
+}
+
+/// Server-specific configuration
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Server process title
+    pub proc_title: String,
+    
+    /// Number of databases
+    pub databases: usize,
+    
+    /// Daemonize server (run in background)
+    pub daemonize: bool,
+    
+    /// Log level
+    pub log_level: LogLevel,
+    
+    /// Log file path (empty for stdout)
+    pub log_file: String,
+    
+    /// PID file path
+    pub pid_file: Option<String>,
+    
+    /// Show logo on startup
+    pub show_logo: bool,
+}
+
+/// Memory management configuration
+#[derive(Debug, Clone)]
+pub struct MemoryConfig {
+    /// Maximum memory to use (0 = unlimited)
+    pub max_memory: usize,
+    
+    /// Eviction policy when memory limit is reached
+    pub max_memory_policy: EvictionPolicy,
+    
+    /// Sample size for eviction (number of keys to sample)
+    pub max_memory_samples: usize,
+}
+
+/// Log level configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Debug level - most verbose
+    Debug,
+    
+    /// Verbose level
+    Verbose,
+    
+    /// Notice level - default
+    Notice,
+    
+    /// Warning level
+    Warning,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            server: ServerConfig::default(),
+            network: NetworkConfig::default(),
+            rdb: RdbConfig::default(),
+            aof: AofConfig::default(),
+            replication: ReplicationConfig::default(),
+            memory: MemoryConfig::default(),
+        }
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+            proc_title: "ferrous-server".to_string(),
+            databases: 16,
+            daemonize: false,
+            log_level: LogLevel::Notice,
+            log_file: "".to_string(),
+            pid_file: None,
+            show_logo: true,
+        }
+    }
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        MemoryConfig {
+            max_memory: 0, // Unlimited
+            max_memory_policy: EvictionPolicy::NoEviction,
+            max_memory_samples: 5,
+        }
+    }
+}
+
+impl Config {
+    /// Load configuration from a file
+    pub fn from_file(path: impl Into<PathBuf>) -> Result<Self, ConfigParseError> {
+        let path = path.into();
+        parse_config_file(&path)
+    }
+    
+    /// Apply command-line arguments to override config
+    pub fn apply_cli_args(&mut self, args: CliArgs) {
+        // Apply network overrides
+        if let Some(port) = args.port {
+            self.network.port = port;
+        }
+        if let Some(bind_addr) = args.bind {
+            self.network.bind_addr = bind_addr;
+        }
+        if let Some(password) = args.password {
+            self.network.password = Some(password);
+        }
+        
+        // Apply replication overrides
+        if let Some((host, port)) = args.replicaof {
+            self.replication.master_host = Some(host);
+            self.replication.master_port = Some(port);
+        }
+        
+        // Apply server config overrides
+        if let Some(log_file) = args.logfile {
+            self.server.log_file = log_file;
+        }
+        if let Some(dir) = args.dir {
+            self.rdb.dir = dir.clone();
+            self.aof.dir = dir;
+        }
+        
+        // Apply persistence overrides
+        if let Some(dbfilename) = args.dbfilename {
+            self.rdb.filename = dbfilename;
+        }
+        if args.appendonly {
+            self.aof.enabled = true;
+        }
+    }
+    
+    /// Get a configuration parameter by name
+    pub fn get(&self, param: &str) -> Option<String> {
+        match param {
+            "port" => Some(self.network.port.to_string()),
+            "bind" => Some(self.network.bind_addr.clone()),
+            "timeout" => Some(self.network.timeout.to_string()),
+            "tcp-keepalive" => self.network.tcp_keepalive.map(|v| v.to_string()),
+            "protected-mode" => Some("yes".to_string()), // Always enabled
+            "databases" => Some(self.server.databases.to_string()),
+            "dbfilename" => Some(self.rdb.filename.clone()),
+            "dir" => Some(self.rdb.dir.clone()),
+            "maxmemory" => Some(self.memory.max_memory.to_string()),
+            "maxmemory-policy" => Some(self.memory_policy_str()),
+            "appendonly" => Some(if self.aof.enabled { "yes" } else { "no" }.to_string()),
+            "appendfilename" => Some(self.aof.filename.clone()),
+            "appendfsync" => Some(self.fsync_policy_str()),
+            "save" => Some(self.format_save_rules()),
+            _ => None,
+        }
+    }
+    
+    /// Get all configuration parameters
+    pub fn get_all(&self) -> Vec<(String, String)> {
+        let mut params = Vec::new();
+        
+        // Network params
+        params.push(("port".to_string(), self.network.port.to_string()));
+        params.push(("bind".to_string(), self.network.bind_addr.clone()));
+        params.push(("timeout".to_string(), self.network.timeout.to_string()));
+        if let Some(keepalive) = self.network.tcp_keepalive {
+            params.push(("tcp-keepalive".to_string(), keepalive.to_string()));
+        }
+        params.push(("protected-mode".to_string(), "yes".to_string()));
+        
+        // Server params
+        params.push(("databases".to_string(), self.server.databases.to_string()));
+        params.push(("daemonize".to_string(), if self.server.daemonize { "yes" } else { "no" }.to_string()));
+        
+        // RDB params
+        params.push(("dbfilename".to_string(), self.rdb.filename.clone()));
+        params.push(("dir".to_string(), self.rdb.dir.clone()));
+        params.push(("save".to_string(), self.format_save_rules()));
+        
+        // AOF params
+        params.push(("appendonly".to_string(), if self.aof.enabled { "yes" } else { "no" }.to_string()));
+        params.push(("appendfilename".to_string(), self.aof.filename.clone()));
+        params.push(("appendfsync".to_string(), self.fsync_policy_str()));
+        
+        // Memory params
+        params.push(("maxmemory".to_string(), self.memory.max_memory.to_string()));
+        params.push(("maxmemory-policy".to_string(), self.memory_policy_str()));
+        
+        params
+    }
+    
+    // Helper methods for formatting
+    
+    fn format_save_rules(&self) -> String {
+        let mut result = String::new();
+        for (seconds, changes) in &self.rdb.save_rules {
+            if !result.is_empty() {
+                result.push(' ');
+            }
+            result.push_str(&format!("{} {}", seconds, changes));
+        }
+        result
+    }
+    
+    fn memory_policy_str(&self) -> String {
+        match self.memory.max_memory_policy {
+            EvictionPolicy::NoEviction => "noeviction".to_string(),
+            EvictionPolicy::AllKeysLru => "allkeys-lru".to_string(),
+            EvictionPolicy::VolatileLru => "volatile-lru".to_string(),
+            EvictionPolicy::AllKeysRandom => "allkeys-random".to_string(),
+            EvictionPolicy::VolatileRandom => "volatile-random".to_string(),
+            EvictionPolicy::VolatileTtl => "volatile-ttl".to_string(),
+        }
+    }
+    
+    fn fsync_policy_str(&self) -> String {
+        match self.aof.fsync_policy {
+            crate::storage::aof::FsyncPolicy::Always => "always".to_string(),
+            crate::storage::aof::FsyncPolicy::EverySecond => "everysec".to_string(),
+            crate::storage::aof::FsyncPolicy::No => "no".to_string(),
+        }
+    }
+}
+
+/// Errors that can occur during configuration
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// Configuration file parse error
+    #[error("Failed to parse config: {0}")]
+    Parse(#[from] ConfigParseError),
+    
+    /// IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    
+    /// Other errors
+    #[error("Configuration error: {0}")]
+    Other(String),
+}

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,0 +1,359 @@
+//! Configuration file parser
+//!
+//! Parses Redis-compatible configuration files for Ferrous.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use crate::network::NetworkConfig;
+use crate::storage::{RdbConfig, AofConfig};
+use crate::storage::memory::EvictionPolicy;
+use crate::storage::aof::FsyncPolicy;
+use crate::replication::ReplicationConfig;
+
+use super::{Config, ServerConfig, MemoryConfig, LogLevel};
+
+/// Error type for configuration parsing
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigParseError {
+    /// IO error
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    
+    /// Invalid line format
+    #[error("Invalid line format at line {0}: {1}")]
+    Format(usize, String),
+    
+    /// Invalid parameter value
+    #[error("Invalid value for parameter '{0}' at line {1}: {2}")]
+    Value(String, usize, String),
+    
+    /// Unknown parameter
+    #[error("Unknown parameter '{0}' at line {1}")]
+    UnknownParam(String, usize),
+}
+
+/// Parse a Redis-compatible configuration file
+pub fn parse_config_file(path: &Path) -> Result<Config, ConfigParseError> {
+    let file = File::open(path)
+        .map_err(ConfigParseError::Io)?;
+    
+    let reader = BufReader::new(file);
+    let mut config = Config::default();
+    
+    // Update dir paths based on config file location
+    if let Some(parent) = path.parent() {
+        config.rdb.dir = parent.to_string_lossy().to_string();
+        // Also update any other path-relative configs
+    }
+    
+    for (line_num, line_result) in reader.lines().enumerate() {
+        let line = line_result?;
+        let line = line.trim();
+        
+        // Skip empty lines and comments
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        
+        // Split the line into parameter and value
+        let parts: Vec<&str> = line.splitn(2, ' ').collect();
+        if parts.len() != 2 {
+            return Err(ConfigParseError::Format(line_num + 1, line.to_string()));
+        }
+        
+        let param = parts[0].trim().to_lowercase();
+        let value = parts[1].trim();
+        
+        // Apply configuration parameter
+        apply_config_param(&mut config, &param, value, line_num + 1)?;
+    }
+    
+    Ok(config)
+}
+
+/// Apply a configuration parameter to the config
+fn apply_config_param(config: &mut Config, param: &str, value: &str, line_num: usize) -> Result<(), ConfigParseError> {
+    match param {
+        // Network settings
+        "bind" => {
+            config.network.bind_addr = value.to_string();
+        }
+        "port" => {
+            config.network.port = parse_value(param, value, line_num)?;
+        }
+        "tcp-backlog" => {
+            config.network.tcp_backlog = parse_value(param, value, line_num)?;
+        }
+        "timeout" => {
+            config.network.timeout = parse_value(param, value, line_num)?;
+        }
+        "tcp-keepalive" => {
+            let keepalive: u64 = parse_value(param, value, line_num)?;
+            config.network.tcp_keepalive = if keepalive == 0 { None } else { Some(keepalive) };
+        }
+        "requirepass" => {
+            config.network.password = Some(value.to_string());
+        }
+        "protected-mode" => {
+            // We only support protected mode on
+            // Just consume the parameter but don't change behavior
+            let _enabled: bool = parse_yes_no(param, value, line_num)?;
+        }
+        
+        // Server settings
+        "daemonize" => {
+            config.server.daemonize = parse_yes_no(param, value, line_num)?;
+        }
+        "databases" => {
+            config.server.databases = parse_value(param, value, line_num)?;
+        }
+        "pidfile" => {
+            config.server.pid_file = if value.is_empty() { None } else { Some(value.to_string()) };
+        }
+        "loglevel" => {
+            config.server.log_level = match value.to_lowercase().as_str() {
+                "debug" => LogLevel::Debug,
+                "verbose" => LogLevel::Verbose,
+                "notice" => LogLevel::Notice,
+                "warning" => LogLevel::Warning,
+                _ => return Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string())),
+            };
+        }
+        "logfile" => {
+            config.server.log_file = value.to_string();
+        }
+        "always-show-logo" => {
+            config.server.show_logo = parse_yes_no(param, value, line_num)?;
+        }
+        
+        // RDB settings
+        "dbfilename" => {
+            config.rdb.filename = value.to_string();
+        }
+        "dir" => {
+            // Both RDB and AOF use this
+            config.rdb.dir = value.to_string();
+            config.aof.dir = value.to_string();
+        }
+        "save" => {
+            if value.is_empty() || value == "\"\"" {
+                // Empty save rule means disable RDB
+                config.rdb.auto_save = false;
+                config.rdb.save_rules.clear();
+            } else {
+                // Parse save rule format: "seconds changes"
+                let parts: Vec<&str> = value.split_whitespace().collect();
+                if parts.len() != 2 {
+                    return Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string()));
+                }
+                
+                let seconds: u64 = parts[0].parse()
+                    .map_err(|_| ConfigParseError::Value(param.to_string(), line_num, value.to_string()))?;
+                
+                let changes: u64 = parts[1].parse()
+                    .map_err(|_| ConfigParseError::Value(param.to_string(), line_num, value.to_string()))?;
+                
+                // Add save rule
+                config.rdb.auto_save = true;
+                config.rdb.save_rules.push((seconds, changes));
+            }
+        }
+        "rdbcompression" => {
+            config.rdb.compress_strings = parse_yes_no(param, value, line_num)?;
+        }
+        
+        // AOF settings
+        "appendonly" => {
+            config.aof.enabled = parse_yes_no(param, value, line_num)?;
+        }
+        "appendfilename" => {
+            config.aof.filename = value.trim_matches('"').to_string();
+        }
+        "appendfsync" => {
+            config.aof.fsync_policy = match value {
+                "always" => FsyncPolicy::Always,
+                "everysec" => FsyncPolicy::EverySecond,
+                "no" => FsyncPolicy::No,
+                _ => return Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string())),
+            };
+        }
+        "auto-aof-rewrite-percentage" => {
+            config.aof.auto_rewrite_percentage = parse_value(param, value, line_num)?;
+        }
+        "auto-aof-rewrite-min-size" => {
+            // Parse size formats like "64mb"
+            config.aof.auto_rewrite_min_size = parse_size(param, value, line_num)?;
+        }
+
+        // Replication settings
+        "replicaof" | "slaveof" => {
+            let parts: Vec<&str> = value.split_whitespace().collect();
+            if parts.len() != 2 {
+                return Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string()));
+            }
+            
+            let host = parts[0].to_string();
+            let port: u16 = parts[1].parse()
+                .map_err(|_| ConfigParseError::Value(param.to_string(), line_num, value.to_string()))?;
+            
+            if host.to_lowercase() == "no" && port == 1 { // "NO ONE" parsed as "no" + "1"
+                config.replication.master_host = None;
+                config.replication.master_port = None;
+            } else {
+                config.replication.master_host = Some(host);
+                config.replication.master_port = Some(port);
+            }
+        }
+        "repl-backlog-size" => {
+            config.replication.backlog_size = parse_size(param, value, line_num)? as usize;
+        }
+        "repl-timeout" => {
+            config.replication.timeout = parse_value(param, value, line_num)?;
+        }
+        "repl-ping-replica-period" | "repl-ping-slave-period" => {
+            config.replication.ping_replica_period = parse_value(param, value, line_num)?;
+        }
+        "repl-diskless-sync" => {
+            config.replication.diskless_sync = parse_yes_no(param, value, line_num)?;
+        }
+        
+        // Memory settings
+        "maxmemory" => {
+            config.memory.max_memory = parse_size(param, value, line_num)? as usize;
+        }
+        "maxmemory-policy" => {
+            config.memory.max_memory_policy = match value.to_lowercase().as_str() {
+                "noeviction" => EvictionPolicy::NoEviction,
+                "allkeys-lru" => EvictionPolicy::AllKeysLru,
+                "volatile-lru" => EvictionPolicy::VolatileLru,
+                "allkeys-random" => EvictionPolicy::AllKeysRandom,
+                "volatile-random" => EvictionPolicy::VolatileRandom,
+                "volatile-ttl" => EvictionPolicy::VolatileTtl,
+                _ => return Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string())),
+            };
+        }
+        
+        // Ignore other parameters
+        _ => {
+            // Just skip unknown parameters instead of erroring
+            println!("Warning: unknown configuration parameter '{}' at line {} - skipping", param, line_num);
+        }
+    }
+    
+    Ok(())
+}
+
+/// Parse a value that implements FromStr
+fn parse_value<T: FromStr>(param: &str, value: &str, line_num: usize) -> Result<T, ConfigParseError> {
+    value.parse::<T>()
+        .map_err(|_| ConfigParseError::Value(param.to_string(), line_num, value.to_string()))
+}
+
+/// Parse a yes/no value
+fn parse_yes_no(param: &str, value: &str, line_num: usize) -> Result<bool, ConfigParseError> {
+    match value.to_lowercase().as_str() {
+        "yes" | "1" => Ok(true),
+        "no" | "0" => Ok(false),
+        _ => Err(ConfigParseError::Value(param.to_string(), line_num, value.to_string())),
+    }
+}
+
+/// Parse a size value (e.g., 64mb, 2gb)
+fn parse_size(param: &str, value: &str, line_num: usize) -> Result<u64, ConfigParseError> {
+    let value = value.trim().to_lowercase();
+    let mut chars = value.chars();
+    
+    // Find the end of the numeric part
+    let mut idx = 0;
+    while let Some(c) = chars.next() {
+        if !c.is_ascii_digit() {
+            break;
+        }
+        idx += 1;
+    }
+    
+    // Parse the numeric part
+    if idx == 0 {
+        return Err(ConfigParseError::Value(param.to_string(), line_num, value.clone()));
+    }
+    let num_part = &value[..idx];
+    let num: u64 = num_part.parse()
+        .map_err(|_| ConfigParseError::Value(param.to_string(), line_num, value.clone()))?;
+    
+    // Parse the unit part
+    let unit_part = &value[idx..];
+    let multiplier = match unit_part {
+        "" => 1, // No unit, just bytes
+        "b" => 1,
+        "kb" => 1024,
+        "mb" => 1024 * 1024,
+        "gb" => 1024 * 1024 * 1024,
+        _ => return Err(ConfigParseError::Value(param.to_string(), line_num, value)),
+    };
+    
+    Ok(num * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::write;
+    use tempfile::NamedTempFile;
+    
+    #[test]
+    fn test_parse_basic_config() {
+        let config_content = r#"
+# This is a comment
+bind 192.168.1.1
+port 9999
+requirepass secretpassword
+
+# Persistence
+save 900 1
+save 300 10
+save 60 10000
+dir ./data
+dbfilename dump.ferrous.rdb
+
+# Replication
+replicaof 192.168.1.100 6379
+"#;
+        
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path();
+        write(path, config_content).unwrap();
+        
+        let config = parse_config_file(path).unwrap();
+        
+        assert_eq!(config.network.bind_addr, "192.168.1.1");
+        assert_eq!(config.network.port, 9999);
+        assert_eq!(config.network.password, Some("secretpassword".to_string()));
+        
+        assert_eq!(config.rdb.filename, "dump.ferrous.rdb");
+        assert_eq!(config.rdb.dir, path.parent().unwrap().to_string_lossy().to_string());
+        
+        assert_eq!(config.replication.master_host, Some("192.168.1.100".to_string()));
+        assert_eq!(config.replication.master_port, Some(6379));
+    }
+    
+    #[test]
+    fn test_parse_yes_no() {
+        assert_eq!(parse_yes_no("test", "yes", 1).unwrap(), true);
+        assert_eq!(parse_yes_no("test", "no", 1).unwrap(), false);
+        assert_eq!(parse_yes_no("test", "1", 1).unwrap(), true);
+        assert_eq!(parse_yes_no("test", "0", 1).unwrap(), false);
+        assert!(parse_yes_no("test", "invalid", 1).is_err());
+    }
+    
+    #[test]
+    fn test_parse_size() {
+        assert_eq!(parse_size("test", "1024", 1).unwrap(), 1024);
+        assert_eq!(parse_size("test", "1kb", 1).unwrap(), 1024);
+        assert_eq!(parse_size("test", "1mb", 1).unwrap(), 1024 * 1024);
+        assert_eq!(parse_size("test", "1gb", 1).unwrap(), 1024 * 1024 * 1024);
+        assert!(parse_size("test", "invalid", 1).is_err());
+    }
+}

--- a/src/replication/manager.rs
+++ b/src/replication/manager.rs
@@ -1,0 +1,419 @@
+//! Replication manager - coordinates all replication activities
+
+use std::sync::{Arc, Mutex, RwLock};
+use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::{Instant, Duration};
+use std::thread;
+use crate::error::{FerrousError, Result};
+use crate::protocol::RespFrame;
+use crate::storage::StorageEngine;
+use crate::network::Connection;
+use super::{ReplicaInfo, ReplicationConfig, ReplicationBacklog, generate_repl_id};
+use super::client::{start_background_replication, ReplicationClientConfig};
+
+/// The role of the server in replication
+#[derive(Debug, Clone)]
+pub enum ReplicationRole {
+    /// This server is a master
+    Master {
+        /// Replication ID
+        repl_id: String,
+        
+        /// Second replication ID (for PSYNC2)
+        repl_id2: String,
+        
+        /// Replication offset
+        repl_offset: Arc<AtomicU64>,
+        
+        /// Second replication offset 
+        repl_offset2: Arc<AtomicU64>,
+    },
+    
+    /// This server is a replica
+    Replica {
+        /// Master address
+        master_addr: SocketAddr,
+        
+        /// Master link status
+        master_link_status: MasterLinkStatus,
+        
+        /// Master replication ID
+        master_repl_id: String,
+        
+        /// Replication offset
+        repl_offset: u64,
+    },
+}
+
+impl PartialEq for ReplicationRole {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Master { repl_id: id1, .. }, Self::Master { repl_id: id2, .. }) => id1 == id2,
+            (Self::Replica { master_addr: addr1, .. }, Self::Replica { master_addr: addr2, .. }) => addr1 == addr2,
+            _ => false,
+        }
+    }
+}
+
+/// Master link status for replicas
+#[derive(Debug, Clone, PartialEq)]
+pub enum MasterLinkStatus {
+    /// Connecting to master
+    Connecting,
+    
+    /// Performing synchronization
+    Synchronizing,
+    
+    /// Link is up and replication is active
+    Up,
+    
+    /// Link is down
+    Down,
+}
+
+/// Current replication state
+#[derive(Debug)]
+pub enum ReplicationState {
+    /// Not replicating
+    None,
+    
+    /// Waiting for BGSAVE to start
+    WaitBgsaveStart,
+    
+    /// Waiting for BGSAVE to end
+    WaitBgsaveEnd,
+    
+    /// Sending RDB file
+    SendingRdb,
+    
+    /// Online - normal replication
+    Online,
+}
+
+/// Main replication manager
+pub struct ReplicationManager {
+    /// Current role (master or replica)
+    role: Arc<RwLock<ReplicationRole>>,
+    
+    /// Replication configuration
+    config: ReplicationConfig,
+    
+    /// Connected replicas (for master)
+    replicas: Arc<Mutex<HashMap<u64, Arc<ReplicaInfo>>>>,
+    
+    /// Replication backlog (for master)
+    backlog: Arc<ReplicationBacklog>,
+    
+    /// Current replication state
+    state: Arc<Mutex<ReplicationState>>,
+    
+    /// Flag to pause replication
+    paused: AtomicBool,
+    
+    /// Master connection ID (for replica)
+    master_conn_id: Arc<Mutex<Option<u64>>>,
+    
+    /// Handle to stop background replication
+    replication_stop_flag: Arc<Mutex<Option<Arc<AtomicBool>>>>,
+}
+
+impl ReplicationManager {
+    /// Create a new replication manager
+    pub fn new(config: ReplicationConfig) -> Arc<Self> {
+        let backlog_size = config.backlog_size;
+        
+        Arc::new(ReplicationManager {
+            role: Arc::new(RwLock::new(ReplicationRole::Master {
+                repl_id: generate_repl_id(),
+                repl_id2: "0000000000000000000000000000000000000000".to_string(),
+                repl_offset: Arc::new(AtomicU64::new(0)),
+                repl_offset2: Arc::new(AtomicU64::new(0)),
+            })),
+            config,
+            replicas: Arc::new(Mutex::new(HashMap::new())),
+            backlog: Arc::new(ReplicationBacklog::new(backlog_size)),
+            state: Arc::new(Mutex::new(ReplicationState::None)),
+            paused: AtomicBool::new(false),
+            master_conn_id: Arc::new(Mutex::new(None)),
+            replication_stop_flag: Arc::new(Mutex::new(None)),
+        })
+    }
+    
+    /// Get current role
+    pub fn role(&self) -> ReplicationRole {
+        self.role.read().unwrap().clone()
+    }
+    
+    /// Check if this server is a master
+    pub fn is_master(&self) -> bool {
+        matches!(*self.role.read().unwrap(), ReplicationRole::Master { .. })
+    }
+    
+    /// Check if this server is a replica
+    pub fn is_replica(&self) -> bool {
+        matches!(*self.role.read().unwrap(), ReplicationRole::Replica { .. })
+    }
+    
+    /// Get current replication offset
+    pub fn get_repl_offset(&self) -> u64 {
+        match &*self.role.read().unwrap() {
+            ReplicationRole::Master { repl_offset, .. } => {
+                repl_offset.load(Ordering::SeqCst)
+            }
+            ReplicationRole::Replica { repl_offset, .. } => *repl_offset,
+        }
+    }
+    
+    /// Set master (for REPLICAOF command)
+    pub fn set_master(&self, master_addr: Option<SocketAddr>, storage: Arc<StorageEngine>) -> Result<()> {
+        // Stop any existing replication
+        {
+            let mut stop_flag = self.replication_stop_flag.lock().unwrap();
+            if let Some(flag) = stop_flag.take() {
+                flag.store(true, Ordering::SeqCst);
+                // Give the replication thread time to stop
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+        
+        let mut role = self.role.write().unwrap();
+        
+        match master_addr {
+            Some(addr) => {
+                // Becoming a replica
+                *role = ReplicationRole::Replica {
+                    master_addr: addr,
+                    master_link_status: MasterLinkStatus::Connecting,
+                    master_repl_id: String::new(),
+                    repl_offset: 0,
+                };
+                
+                // Clear connected replicas
+                self.replicas.lock().unwrap().clear();
+                
+                // Reset state
+                *self.state.lock().unwrap() = ReplicationState::None;
+                
+                // Start background replication
+                let config = ReplicationClientConfig::default();
+                let stop_flag = start_background_replication(
+                    addr,
+                    config,
+                    Arc::new(self.clone()),
+                    Arc::clone(&storage),
+                );
+                
+                // Store stop flag
+                *self.replication_stop_flag.lock().unwrap() = Some(stop_flag);
+                
+                Ok(())
+            }
+            None => {
+                // Becoming a master (REPLICAOF NO ONE)
+                *role = ReplicationRole::Master {
+                    repl_id: generate_repl_id(),
+                    repl_id2: "0000000000000000000000000000000000000000".to_string(),
+                    repl_offset: Arc::new(AtomicU64::new(0)),
+                    repl_offset2: Arc::new(AtomicU64::new(0)),
+                };
+                
+                // Reset state
+                *self.state.lock().unwrap() = ReplicationState::None;
+                
+                Ok(())
+            }
+        }
+    }
+    
+    /// Add a replica (for master)
+    pub fn add_replica(&self, replica: Arc<ReplicaInfo>) -> Result<()> {
+        if !self.is_master() {
+            return Err(FerrousError::Command(
+                crate::error::CommandError::Generic("not a master".into())
+            ));
+        }
+        
+        let mut replicas = self.replicas.lock().unwrap();
+        replicas.insert(replica.conn_id, replica);
+        
+        Ok(())
+    }
+    
+    /// Remove a replica (for master)
+    pub fn remove_replica(&self, conn_id: u64) -> Option<Arc<ReplicaInfo>> {
+        let mut replicas = self.replicas.lock().unwrap();
+        replicas.remove(&conn_id)
+    }
+    
+    /// Get all connected replicas (for master)
+    pub fn get_replicas(&self) -> Vec<Arc<ReplicaInfo>> {
+        let replicas = self.replicas.lock().unwrap();
+        replicas.values().cloned().collect()
+    }
+    
+    /// Propagate command to all replicas (for master)
+    pub fn propagate_command(&self, cmd_frame: &RespFrame) -> Result<Vec<u64>> {
+        if !self.is_master() {
+            return Ok(Vec::new());
+        }
+        
+        // Add to backlog
+        self.backlog.append_command(cmd_frame)?;
+        
+        // Get current replication offset
+        let offset = match &*self.role.read().unwrap() {
+            ReplicationRole::Master { repl_offset, .. } => {
+                repl_offset.fetch_add(1, Ordering::SeqCst)
+            }
+            _ => return Ok(Vec::new()),
+        };
+        
+        // Get replica connection IDs
+        let replicas = self.replicas.lock().unwrap();
+        let replica_ids: Vec<u64> = replicas.keys().cloned().collect();
+        
+        Ok(replica_ids)
+    }
+    
+    /// Update master link status (for replica)
+    pub fn update_master_link_status(&self, status: MasterLinkStatus) -> Result<()> {
+        let mut role = self.role.write().unwrap();
+        
+        match &mut *role {
+            ReplicationRole::Replica { master_link_status, .. } => {
+                *master_link_status = status;
+                Ok(())
+            }
+            _ => Err(FerrousError::Command(
+                crate::error::CommandError::Generic("not a replica".into())
+            )),
+        }
+    }
+    
+    /// Update replication offset (for replica)
+    pub fn update_replica_offset(&self, offset: u64, master_repl_id: Option<String>) -> Result<()> {
+        let mut role = self.role.write().unwrap();
+        
+        match &mut *role {
+            ReplicationRole::Replica { repl_offset, master_repl_id: stored_id, .. } => {
+                *repl_offset = offset;
+                if let Some(id) = master_repl_id {
+                    *stored_id = id;
+                }
+                Ok(())
+            }
+            _ => Err(FerrousError::Command(
+                crate::error::CommandError::Generic("not a replica".into())
+            )),
+        }
+    }
+    
+    /// Check if replication is paused
+    pub fn is_paused(&self) -> bool {
+        self.paused.load(Ordering::SeqCst)
+    }
+    
+    /// Pause replication
+    pub fn pause(&self) {
+        self.paused.store(true, Ordering::SeqCst);
+    }
+    
+    /// Resume replication
+    pub fn resume(&self) {
+        self.paused.store(false, Ordering::SeqCst);
+    }
+    
+    /// Get replication info for INFO command
+    pub fn get_info(&self) -> HashMap<String, String> {
+        let mut info = HashMap::new();
+        
+        match &*self.role.read().unwrap() {
+            ReplicationRole::Master { repl_id, repl_offset, .. } => {
+                info.insert("role".to_string(), "master".to_string());
+                info.insert("repl_id".to_string(), repl_id.clone());
+                info.insert("repl_offset".to_string(), 
+                    repl_offset.load(Ordering::SeqCst).to_string());
+                
+                let replicas = self.replicas.lock().unwrap();
+                info.insert("connected_slaves".to_string(), replicas.len().to_string());
+                
+                // Add replica info
+                for (idx, (_, replica)) in replicas.iter().enumerate() {
+                    let key = format!("slave{}", idx);
+                    let value = format!("ip={},port=0,state=online,offset={},lag=0",
+                        replica.addr.ip(),
+                        replica.ack_offset.load(Ordering::SeqCst));
+                    info.insert(key, value);
+                }
+            }
+            ReplicationRole::Replica { master_addr, master_link_status, repl_offset, .. } => {
+                info.insert("role".to_string(), "slave".to_string());
+                info.insert("master_host".to_string(), master_addr.ip().to_string());
+                info.insert("master_port".to_string(), master_addr.port().to_string());
+                info.insert("master_link_status".to_string(), 
+                    match master_link_status {
+                        MasterLinkStatus::Up => "up",
+                        MasterLinkStatus::Down => "down",
+                        MasterLinkStatus::Connecting => "connecting",
+                        MasterLinkStatus::Synchronizing => "sync",
+                    }.to_string()
+                );
+                info.insert("slave_repl_offset".to_string(), repl_offset.to_string());
+            }
+        }
+        
+        info
+    }
+    
+    /// Get backlog data from a specific offset
+    pub fn get_backlog_data(&self, offset: u64) -> Result<Vec<u8>> {
+        self.backlog.get_data_from_offset(offset)
+    }
+}
+
+impl Clone for ReplicationManager {
+    fn clone(&self) -> Self {
+        Self {
+            role: Arc::clone(&self.role),
+            config: self.config.clone(),
+            replicas: Arc::clone(&self.replicas),
+            backlog: Arc::clone(&self.backlog),
+            state: Arc::clone(&self.state),
+            paused: AtomicBool::new(self.paused.load(Ordering::SeqCst)),
+            master_conn_id: Arc::clone(&self.master_conn_id),
+            replication_stop_flag: Arc::clone(&self.replication_stop_flag),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_replication_manager_creation() {
+        let config = ReplicationConfig::default();
+        let manager = ReplicationManager::new(config);
+        
+        assert!(manager.is_master());
+        assert!(!manager.is_replica());
+    }
+    
+    #[test]
+    fn test_set_master() {
+        let config = ReplicationConfig::default();
+        let manager = ReplicationManager::new(config);
+        let storage = Arc::new(StorageEngine::new());
+        
+        // Set as replica
+        let addr = "127.0.0.1:6379".parse().unwrap();
+        manager.set_master(Some(addr), Arc::clone(&storage)).unwrap();
+        assert!(manager.is_replica());
+        
+        // Set back to master
+        manager.set_master(None, Arc::clone(&storage)).unwrap();
+        assert!(manager.is_master());
+    }
+}

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1,0 +1,149 @@
+//! Replication module for ferrous
+//! 
+//! Implements Redis-compatible master-slave replication including:
+//! - REPLICAOF command support
+//! - Full synchronization via RDB
+//! - Incremental sync (PSYNC)
+//! - Command propagation
+//! - Replication backlog
+
+mod manager;
+pub mod sync; // Make the sync module public
+pub mod commands;
+mod backlog;
+mod client;
+
+pub use manager::{ReplicationManager, ReplicationRole, ReplicationState, MasterLinkStatus};
+pub use sync::{SyncProtocol, PsyncResult}; // Re-export SyncProtocol
+pub use commands::{handle_replicaof, handle_replconf, handle_slaveof, handle_sync, handle_psync};
+pub use backlog::ReplicationBacklog;
+pub use client::{start_background_replication, ReplicationClientConfig};
+
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::net::SocketAddr;
+
+/// Replication configuration
+#[derive(Debug, Clone)]
+pub struct ReplicationConfig {
+    /// Maximum size of the replication backlog
+    pub backlog_size: usize,
+    
+    /// Replication timeout (in seconds)
+    pub timeout: u64,
+    
+    /// Ping replica period (in seconds)
+    pub ping_replica_period: u64,
+    
+    /// Enable diskless replication
+    pub diskless_sync: bool,
+    
+    /// Master host to replicate from (if this is a replica)
+    pub master_host: Option<String>,
+    
+    /// Master port to replicate from (if this is a replica)
+    pub master_port: Option<u16>,
+}
+
+impl Default for ReplicationConfig {
+    fn default() -> Self {
+        ReplicationConfig {
+            backlog_size: 1_048_576, // 1MB default
+            timeout: 60,
+            ping_replica_period: 10,
+            diskless_sync: false,
+            master_host: None,
+            master_port: None,
+        }
+    }
+}
+
+/// Information about a connected replica
+#[derive(Debug)]
+pub struct ReplicaInfo {
+    /// Connection ID of the replica
+    pub conn_id: u64,
+    
+    /// Address of the replica
+    pub addr: SocketAddr,
+    
+    /// Replication offset acknowledged by the replica
+    pub ack_offset: AtomicU64,
+    
+    /// Last interaction time
+    pub last_interaction: Mutex<Instant>,
+    
+    /// Replica capabilities
+    pub capabilities: Vec<String>,
+}
+
+impl ReplicaInfo {
+    pub fn new(conn_id: u64, addr: SocketAddr) -> Arc<Self> {
+        Arc::new(ReplicaInfo {
+            conn_id,
+            addr,
+            ack_offset: AtomicU64::new(0),
+            last_interaction: Mutex::new(Instant::now()),
+            capabilities: Vec::new(),
+        })
+    }
+    
+    /// Update last interaction time
+    pub fn touch(&self) {
+        *self.last_interaction.lock().unwrap() = Instant::now();
+    }
+    
+    /// Get time since last interaction
+    pub fn idle_time(&self) -> std::time::Duration {
+        self.last_interaction.lock().unwrap().elapsed()
+    }
+    
+    /// Update acknowledged offset
+    pub fn update_ack_offset(&self, offset: u64) {
+        self.ack_offset.store(offset, Ordering::SeqCst);
+    }
+}
+
+/// Generate a unique replication ID
+pub fn generate_repl_id() -> String {
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    let bytes: Vec<u8> = (0..40)
+        .map(|_| {
+            let n = rng.gen_range(0..62);
+            match n {
+                0..=9 => (b'0' + n) as u8,
+                10..=35 => (b'a' + n - 10) as u8,
+                36..=61 => (b'A' + n - 36) as u8,
+                _ => unreachable!(),
+            }
+        })
+        .collect();
+    
+    String::from_utf8(bytes).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_generate_repl_id() {
+        let id = generate_repl_id();
+        assert_eq!(id.len(), 40);
+        assert!(id.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+    
+    #[test]
+    fn test_replica_info() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
+        let replica = ReplicaInfo::new(1, addr);
+        
+        assert_eq!(replica.conn_id, 1);
+        assert_eq!(replica.ack_offset.load(Ordering::SeqCst), 0);
+        
+        replica.update_ack_offset(100);
+        assert_eq!(replica.ack_offset.load(Ordering::SeqCst), 100);
+    }
+}


### PR DESCRIPTION
## Problem

The ferrous project fails to build due to missing module files that were likely lost during a merge or commit:

```
error[E0583]: file not found for module `replication`
error[E0583]: file not found for module `config`
```

## Solution

This PR adds the missing module files that are required for the build to succeed:

- `src/replication/mod.rs` - Main replication module that exports all replication functionality
- `src/config/mod.rs` - Main configuration module
- `src/config/cli.rs` - CLI argument parsing implementation
- `src/config/parser.rs` - Configuration file parser
- `src/replication/manager.rs` - Replication manager implementation

## Impact

After applying these changes:
- The project builds successfully with `cargo build --release`
- All module imports are resolved
- The server runs properly with full functionality

## Testing

Tested by:
1. Building the project: `cargo build --release` ✅
2. Running the server: `./target/release/ferrous` ✅
3. Running benchmarks to verify performance ✅

The build now completes successfully with only warnings (no errors).

---

**Created by Maestro on behalf of Sean Ward**